### PR TITLE
Remove extra lines from the example code

### DIFF
--- a/docs/deeplearning4j-nlp/templates/word2vec.md
+++ b/docs/deeplearning4j-nlp/templates/word2vec.md
@@ -229,9 +229,6 @@ The next step is to evaluate the quality of your feature vectors.
         log.info("Closest Words:");
         Collection<String> lst = vec.wordsNearest("day", 10);
         System.out.println(lst);
-        UiServer server = UiServer.getInstance();
-        System.out.println("Started on port " + server.getPort());
-        
         //output: [night, week, year, game, season, during, office, until, -]
 ```
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

The example code used to start a UiServer and prints the port to stdout, but this not necessary. This commit deletes the extra lines.
